### PR TITLE
Skip expanding layers already present as targets

### DIFF
--- a/ExpandLayerDependencies.py
+++ b/ExpandLayerDependencies.py
@@ -140,7 +140,7 @@ def expand_rows(rows: Sequence[Dict[str, str]], layer_columns: Sequence[str]) ->
     if SOURCE_COLUMN not in rows[0]:
         raise KeyError(f"Missing required column: {SOURCE_COLUMN}")
 
-    base_targets = {
+    known_targets = {
         _normalise_value(row.get(TARGET_COLUMN))
         for row in rows
         if _normalise_value(row.get(TARGET_COLUMN))
@@ -158,8 +158,10 @@ def expand_rows(rows: Sequence[Dict[str, str]], layer_columns: Sequence[str]) ->
             layer_value = _normalise_value(original.get(layer))
             if not layer_value:
                 continue
-            if layer_value in base_targets:
-                LOGGER.debug("Skip layer '%s' because it already exists as a target", layer_value)
+            if layer_value in known_targets:
+                LOGGER.debug(
+                    "Skip layer '%s' because it already exists as a target", layer_value
+                )
                 continue
 
             new_row: Dict[str, str] = {TARGET_COLUMN: layer_value}
@@ -176,6 +178,7 @@ def expand_rows(rows: Sequence[Dict[str, str]], layer_columns: Sequence[str]) ->
                 new_row[SOURCE_COLUMN] = source_value
 
             grouped_rows.setdefault(layer_value, []).append(new_row)
+            known_targets.add(layer_value)
             LOGGER.debug("Added exploded row for layer '%s'", layer_value)
 
     ordered_targets = []


### PR DESCRIPTION
## Summary
- avoid expanding layer tables that already exist in the target column by tracking known targets during processing

## Testing
- python -m compileall ExpandLayerDependencies.py

------
https://chatgpt.com/codex/tasks/task_e_68de23166178832784c2799018237e7a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Eliminates duplicate layer expansions by recognizing existing targets, reducing redundant processing and improving result accuracy across iterations.
- Refactor
  - Clarified internal naming for readability and maintainability.
- Style
  - Standardized multi-line log formatting for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->